### PR TITLE
Add readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 Documentation
 =============
 
-Look at the API on [GoPkgDoc](gopkgdoc.appspot.com/pkg/github.com/norisatir/go-dbus).
+Look at the API on [GoPkgDoc](http://gopkgdoc.appspot.com/pkg/github.com/norisatir/go-dbus).
 
 Installation
 ============

--- a/README.markdown
+++ b/README.markdown
@@ -13,4 +13,51 @@ Usage
 
 ```go
 import "github.com/norisatir/go-dbus"
+import "log"
+
+func main() {
+    var (
+        err error
+        conn *dbus.Connection
+        out []interface{}
+    )
+
+    // Connect to Session or System buses.
+    if conn, err = dbus.Connect(dbus.SessionBus); err != nil {
+        log.Fatal("Connection error:", err)
+    }
+    if err = conn.Initialize(); err != nil {
+        log.Fatal("Initialization error:", err)
+    }
+
+    // Get objects.
+    obj := conn.GetObject("org.freedesktop.Notifications", "/org/freedesktop/Notifications")
+
+    // Introspect objects.
+    out, err = conn.CallMethod(
+        conn.Interface(obj, "org.freedesktop.DBus.Introspectable"),
+        "Instrospect")
+    if err != nil {
+        log.Fatal("Introspect error:", err)
+    }
+    var intro dbus.Introspect
+    intro, err := dbus.NewIntrospect(out[0])
+    method := intro.GetInterfaceData("org.freedesktop.Notifications").GetMethodData("Notify")
+    log.Printf("%s(%s) (%s)", method.GetName(), method.GetInSignature(), method.GetOutSigniture())
+
+    // Call object methods.
+    out, err = conn.CallMethod(
+        conn.Interface(
+            conn.GetObject("org.freedesktop.Notifications", "/org/freedesktop/Notifications"),
+            "org.freedesktop.Notifications"),
+        "Notify",
+		"dbus-tutorial", uint32(0), "",
+        "dbus-tutorial", "You've been notified!",
+		[]interface{}{}, map[string]interface{}{}, int32(-1))
+    )
+    if err != nil {
+        log.Fatal("Notification error:", err)
+    }
+    log.Print("Notification id:", out[0])
+}
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,8 @@ Usage
 ```go
 // Issue OSD notifications according to the Desktop Notifications Specification 1.1
 //      http://people.canonical.com/~agateau/notifications-1.1/spec/index.html
+// See also
+//      https://wiki.ubuntu.com/NotifyOSD#org.freedesktop.Notifications.Notify
 package main
 
 import "github.com/norisatir/go-dbus"

--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ Usage
 =====
 
 ```go
-// Issue OSD notifications according to the Desktop Notifications Specifications 1.1
+// Issue OSD notifications according to the Desktop Notifications Specification 1.1
 //      http://people.canonical.com/~agateau/notifications-1.1/spec/index.html
 package main
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,16 @@
+Documentation
+=============
+
+Look at the API on [GoPkgDoc](gopkgdoc.appspot.com/pkg/github.com/norisatir/go-dbus).
+
+Installation
+============
+
+    goinstall github.com/norisatir/go-dbus
+
+Usage
+=====
+
+```go
+import "github.com/norisatir/go-dbus"
+```

--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,10 @@ Usage
 =====
 
 ```go
+// Issue OSD notifications according to the Desktop Notifications Specifications 1.1
+//      http://people.canonical.com/~agateau/notifications-1.1/spec/index.html
+package main
+
 import "github.com/norisatir/go-dbus"
 import "log"
 
@@ -35,15 +39,14 @@ func main() {
 
     // Introspect objects.
     out, err = conn.CallMethod(
-        conn.Interface(obj, "org.freedesktop.DBus.Introspectable"),
-        "Instrospect")
+        conn.Interface(obj, "org.freedesktop.DBus.Introspectable"), "Introspect")
     if err != nil {
         log.Fatal("Introspect error:", err)
     }
     var intro dbus.Introspect
-    intro, err := dbus.NewIntrospect(out[0])
+    intro, err = dbus.NewIntrospect(out[0].(string))
     method := intro.GetInterfaceData("org.freedesktop.Notifications").GetMethodData("Notify")
-    log.Printf("%s(%s) (%s)", method.GetName(), method.GetInSignature(), method.GetOutSigniture())
+    log.Printf("%s in:%s out:%s", method.GetName(), method.GetInSignature(), method.GetOutSignature())
 
     // Call object methods.
     out, err = conn.CallMethod(
@@ -54,7 +57,6 @@ func main() {
 		"dbus-tutorial", uint32(0), "",
         "dbus-tutorial", "You've been notified!",
 		[]interface{}{}, map[string]interface{}{}, int32(-1))
-    )
     if err != nil {
         log.Fatal("Notification error:", err)
     }


### PR DESCRIPTION
Add content to the README file, which is renamed README.markdown to enable github markup.

Adds README sections
- **Documentation** pointing to [GoPkgDoc](gopkgdoc.appspot.com/pkg/github.com/norisatir/go-dbus)
- **Installation** telling people that `goinstall` works as expected.
- **Usage** containing a basic example (OSD notifications)

See [my branch's page](https://github.com/bmatsuo/go-dbus/tree/add-README#readme) for a preview of how things are get marked-up.
