### PR TITLE
Objectify API

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,33 @@ Installation
 Usage
 =====
 
+Methods
+-------
+
+Methods is obtained with
+
+    meth, err := conn.Object(dest, path).Interface(iface).Method(method)
+
+They are called with
+
+    out, err := conn.Call(meth)
+
+Signals
+-------
+
+Signals are obtained with
+
+    sig, err := conn.Object(dest, path).Interface(iface).Signal(signal)
+
+they are emitted with
+
+    err = conn.Emit(sig)
+
+**TODO** Add signal handling usage.
+
+An example
+----------
+
 ```go
 // Issue OSD notifications according to the Desktop Notifications Specification 1.1
 //      http://people.canonical.com/~agateau/notifications-1.1/spec/index.html

--- a/dbus.go
+++ b/dbus.go
@@ -122,6 +122,34 @@ type Interface struct {
 	intro InterfaceData
 }
 
+type Method struct {
+	iface *Interface
+	data MethodData
+}
+
+type Signal struct {
+	iface *Interface
+	data SignalData
+}
+
+// Retrieve a method by name.
+func (iface *Interface) Method(name string) (*Method, error) {
+	method := iface.intro.GetMethodData(name)
+	if nil == method {
+		return nil, errors.New("Invalid Method")
+	}
+	return &Method{iface, method}, nil
+}
+
+// Retrieve a signal by name.
+func (iface *Interface) Signal(name string) (*Signal, error) {
+	signal := iface.intro.GetSignalData(name)
+	if nil == signal {
+		return nil, errors.New("Invalid Signalx")
+	}
+	return &Signal{iface, signal}, nil
+}
+
 func Connect(busType StandardBus) (*Connection, error) {
 	var address string
 
@@ -325,20 +353,6 @@ func (p *Connection) _GetProxy() *Interface {
 	return iface
 }
 
-type Method struct {
-	iface *Interface
-	data MethodData
-}
-
-// Retrieve a method by name.
-func (iface *Interface) Method(name string) (*Method, error) {
-	method := iface.intro.GetMethodData(name)
-	if nil == method {
-		return nil, errors.New("Invalid Method")
-	}
-	return &Method{iface, method}, nil
-}
-
 // Call a method with the given arguments.
 func (p *Connection) Call(method *Method, args ...interface{}) ([]interface{}, error) {
 	iface := method.iface
@@ -360,20 +374,6 @@ func (p *Connection) Call(method *Method, args ...interface{}) ([]interface{}, e
 	})
 
 	return ret, nil
-}
-
-type Signal struct {
-	iface *Interface
-	data SignalData
-}
-
-// Retrieve a signal by name.
-func (iface *Interface) Signal(name string) (*Signal, error) {
-	signal := iface.intro.GetSignalData(name)
-	if nil == signal {
-		return nil, errors.New("Invalid Signalx")
-	}
-	return &Signal{iface, signal}, nil
 }
 
 // Emit a signal with the given arguments.

--- a/dbus_test.go
+++ b/dbus_test.go
@@ -7,8 +7,8 @@ import (
 
 type callTest struct {
 	dest, path, iface, method string
-	args []interface{}
-	validate func([]interface{}) error
+	args                      []interface{}
+	validate                  func([]interface{}) error
 }
 
 var callTests = []callTest{
@@ -24,7 +24,7 @@ var callTests = []callTest{
 		}},
 }
 
-func (test callTest) Call(c *Connection) (error) {
+func (test callTest) Call(c *Connection) error {
 	method, err := c.Object(test.dest, test.path).Interface(test.iface).Method(test.method)
 	if err != nil {
 		return err

--- a/dbus_test.go
+++ b/dbus_test.go
@@ -24,21 +24,8 @@ var callTests = []callTest{
 		}},
 }
 
-func (test callTest) Object(c *Connection) *Object {
-	return c.Object(test.dest, test.path)
-}
-func (test callTest) Interface(c *Connection) *Interface {
-	return test.Object(c).Interface(test.iface)
-}
-func (test callTest) Method(c *Connection) (*Method, error) {
-	method, err := test.Interface(c).Method(test.method)
-	if err != nil {
-		err = fmt.Errorf("failed Interface.Method: %v", err)
-	}
-	return method, err
-}
 func (test callTest) Call(c *Connection) (error) {
-	method, err := test.Method(c)
+	method, err := c.Object(test.dest, test.path).Interface(test.iface).Method(test.method)
 	if err != nil {
 		return err
 	}

--- a/introspect.go
+++ b/introspect.go
@@ -57,6 +57,7 @@ type MethodData interface {
 }
 
 type SignalData interface {
+	GetName() string
 	GetSignature() string
 }
 


### PR DESCRIPTION
# Description

This patch will alter the top level API. It would be prudent to **discuss it before merging** into the master repository. The test code in the patch is altered for the new API, as is the README example.

Aside from these changes, I refactored the test code in [dbus_test.go](https://github.com/bmatsuo/go-dbus/blob/objectify-api/dbus_test.go) while I was fixing API calls. It's now a table-driven test that allows more method-call tests to be written.

I've also introduced two new types which I discuss at the bottom of this document.

Please look everything over and give me your feedback. An important part of this should process be planning for future changes the API needs (there are certainly a few).

Thanks.
# Changes

Changes to the existing API affect the *Connection interface. *Object and *Interface have new methods, but otherwise function the same way.
## Connection.Interface

The Connection.Interface method is now Object.Interface. The method did not rely on the connection. Using it as a *Connection method only made things more cumbersome.
## Method calls and signal emitting

The way methods/signals are called/emitted has changed. A method/signal is obtained from *Interface, using method Method/Signal. This object is then passed to the *Connection method Call/Emit (formerly CallMethod/EmitSignal) along with a list of arguments. The new Call/Emit API is outlined in [the updated README](https://github.com/bmatsuo/go-dbus/tree/objectify-api#readme).
## Signal handling

The Connection.AddSignalHandler method has been renamed Connection.Handle. It is slightly more ambiguous. It could be renamed Connection.HandleSignal. I think a more appropriate solution might be let it be named Connection.Handle, but make its argument a 'SignalHandler'. I don't think this type exists (not publicly). But a simple wrapper could take care of that.
## New types

Finally, there are new types Method and Signal. These types combine *Interface objects with MethodData/SignalData objects. This solution is probably not ideal. The MethodData and SignalData types should probably not be exported (either before this request is merged, or sometime in the near future).
