### PR TITLE
Message cleanup

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -243,19 +243,19 @@ func (p *Connection) _MessageDispatch(msg *Message) {
 	}
 
 	switch msg.Type {
-	case METHOD_RETURN:
+	case TypeMethodReturn:
 		rs := msg.replySerial
 		if replyFunc, ok := p.methodCallReplies[rs]; ok {
 			replyFunc(msg)
 			delete(p.methodCallReplies, rs)
 		}
-	case SIGNAL:
+	case TypeSignal:
 		for _, handler := range p.signalMatchRules {
 			if handler.mr._Match(msg) {
 				handler.proc(msg)
 			}
 		}
-	case ERROR:
+	case TypeError:
 		fmt.Println("ERROR")
 	}
 }
@@ -300,7 +300,7 @@ func (p *Connection) _SendHello() error {
 
 func (p *Connection) _GetIntrospect(dest string, path string) Introspect {
 	msg := NewMessage()
-	msg.Type = METHOD_CALL
+	msg.Type = TypeMethodCall
 	msg.Path = path
 	msg.Dest = dest
 	msg.Iface = "org.freedesktop.DBus.Introspectable"
@@ -358,7 +358,7 @@ func (p *Connection) Call(method *Method, args ...interface{}) ([]interface{}, e
 	iface := method.iface
 	msg := NewMessage()
 
-	msg.Type = METHOD_CALL
+	msg.Type = TypeMethodCall
 	msg.Path = iface.obj.path
 	msg.Iface = iface.name
 	msg.Dest = iface.obj.dest
@@ -382,7 +382,7 @@ func (p *Connection) Emit(signal *Signal, args ...interface{}) error {
 
 	msg := NewMessage()
 
-	msg.Type = SIGNAL
+	msg.Type = TypeSignal
 	msg.Path = iface.obj.path
 	msg.Iface = iface.name
 	msg.Dest = iface.obj.dest
@@ -411,6 +411,6 @@ func (p *Connection) Object(dest string, path string) *Object {
 func (p *Connection) Handle(rule *MatchRule, handler func(*Message)) {
 	p.signalMatchRules = append(p.signalMatchRules, signalHandler{*rule, handler})
 	if method, err := p.proxy.Method("AddMatch"); err == nil {
-		p.Call(method, rule._ToString())
+		p.Call(method, rule.String())
 	}
 }

--- a/matchrule.go
+++ b/matchrule.go
@@ -27,7 +27,7 @@ func (p *MatchRule) String() string {
 }
 
 func (p *MatchRule) _Match(msg *Message) bool {
-	if p.Type != msg.Type {
+	if p.Type != TypeInvalid && p.Type != msg.Type {
 		return false
 	}
 	if p.Interface != "" && p.Interface != msg.Iface {

--- a/matchrule.go
+++ b/matchrule.go
@@ -4,38 +4,30 @@ import "reflect"
 import "fmt"
 import "strings"
 
-var typeMap = map[MessageType]string{
-	INVALID:       "invalid",
-	METHOD_CALL:   "method_call",
-	METHOD_RETURN: "method_return",
-	SIGNAL:        "signal",
-	ERROR:         "error",
-}
-
+// Matches all messages with equal type, interface, member, or path.
+// Any missing/invalid fields are not matched against.
 type MatchRule struct {
-	Type      string
+	Type      MessageType
 	Interface string
 	Member    string
 	Path      string
 }
 
-func (p *MatchRule) _ToString() string {
+// A string representation af the MatchRule (D-Bus variant map).
+func (p *MatchRule) String() string {
 	strslice := []string{}
 
 	v := reflect.Indirect(reflect.ValueOf(p))
 	t := v.Type()
-	for i:=0; i<v.NumField(); i++{
-		str, ok := v.Field(i).Interface().(string)
-		if ok && "" != str{
-			strslice = append(strslice, (fmt.Sprintf("%s='%s'", strings.ToLower(t.Field(i).Name), str)))
-		}	
+	for i := 0; i < v.NumField(); i++ {
+		strslice = append(strslice, (fmt.Sprintf("%s='%v'", strings.ToLower(t.Field(i).Name), v.Field(i).Interface())))
 	}
-	
+
 	return strings.Join(strslice, ",")
 }
 
 func (p *MatchRule) _Match(msg *Message) bool {
-	if p.Type != "" && p.Type != typeMap[msg.Type] {
+	if p.Type != msg.Type {
 		return false
 	}
 	if p.Interface != "" && p.Interface != msg.Iface {

--- a/matchrule_test.go
+++ b/matchrule_test.go
@@ -8,12 +8,12 @@ func TestToString(t *testing.T) {
 	verifyStr := "type='signal',interface='org.freedesktop.DBus',member='Foo',path='/bar/foo'"
 
 	mr := MatchRule{
-		Type:      "signal",
+		Type:      TypeSignal,
 		Interface: "org.freedesktop.DBus",
 		Member:    "Foo",
 		Path:      "/bar/foo"}
 
-	if mr._ToString() != verifyStr {
+	if mr.String() != verifyStr {
 		t.Error("#1 Failed")
 	}
 }

--- a/message.go
+++ b/message.go
@@ -30,8 +30,8 @@ func (t MessageType) String() string { return messageTypeString[t] }
 type MessageFlag uint8
 
 const (
-	NoReplyExpected MessageFlag = 1 << iota
-	NoAutoStart
+	FlagNoReplyExpected MessageFlag = 1 << iota
+	FlagNoAutoStart
 )
 
 type Message struct {

--- a/message.go
+++ b/message.go
@@ -62,6 +62,7 @@ func _GetNewSerial() int {
 	return serial
 }
 
+// Create a new message with Flags == 0 and Protocol == 1.
 func NewMessage() *Message {
 	msg := new(Message)
 

--- a/message.go
+++ b/message.go
@@ -8,12 +8,22 @@ import (
 type MessageType int
 
 const (
-	INVALID       = 0
-	METHOD_CALL   = 1
-	METHOD_RETURN = 2
-	ERROR         = 3
-	SIGNAL        = 4
+	TypeInvalid = iota
+	TypeMethodCall
+	TypeMethodReturn
+	TypeError
+	TypeSignal
 )
+
+var messageTypeString = map[MessageType]string{
+	TypeInvalid:      "invalid",
+	TypeMethodCall:   "method_call",
+	TypeMethodReturn: "method_return",
+	TypeSignal:       "signal",
+	TypeError:        "error",
+}
+
+func (t MessageType) String() string { return messageTypeString[t] }
 
 type MessageFlag int
 

--- a/message.go
+++ b/message.go
@@ -10,7 +10,7 @@ import (
 type MessageType int
 
 const (
-	TypeInvalid = iota
+	TypeInvalid MessageType = iota
 	TypeMethodCall
 	TypeMethodReturn
 	TypeError

--- a/message.go
+++ b/message.go
@@ -7,7 +7,7 @@ import (
 
 // See the D-Bus tutorial for information about message types.
 //		http://dbus.freedesktop.org/doc/dbus-tutorial.html#messages
-type MessageType int
+type MessageType uint8
 
 const (
 	TypeInvalid MessageType = iota
@@ -27,11 +27,11 @@ var messageTypeString = map[MessageType]string{
 
 func (t MessageType) String() string { return messageTypeString[t] }
 
-type MessageFlag int
+type MessageFlag uint8
 
 const (
-	NO_REPLY_EXPECTED = 0x1
-	NO_AUTO_START     = 0x2
+	NoReplyExpected MessageFlag = 1 << iota
+	NoAutoStart
 )
 
 type Message struct {

--- a/message.go
+++ b/message.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 )
 
+// See the D-Bus tutorial for information about message types.
+//		http://dbus.freedesktop.org/doc/dbus-tutorial.html#messages
 type MessageType int
 
 const (

--- a/message_test.go
+++ b/message_test.go
@@ -10,7 +10,7 @@ func TestUnmarshal(t *testing.T) {
 	if nil != e {
 		t.Error("Unmarshal Failed")
 	}
-	if METHOD_CALL != msg.Type {
+	if TypeMethodCall != msg.Type {
 		t.Error("#1 Failed :", msg.Type)
 	}
 	if "/org/freedesktop/DBus" != msg.Path {
@@ -31,7 +31,7 @@ func TestMarshal(t *testing.T) {
 	teststr := "l\x01\x00\x01\x00\x00\x00\x00\x01\x00\x00\x00m\x00\x00\x00\x01\x01o\x00\x15\x00\x00\x00/org/freedesktop/DBus\x00\x00\x00\x02\x01s\x00\x14\x00\x00\x00org.freedesktop.DBus\x00\x00\x00\x00\x03\x01s\x00\x05\x00\x00\x00Hello\x00\x00\x00\x06\x01s\x00\x14\x00\x00\x00org.freedesktop.DBus\x00\x00\x00\x00"
 
 	msg := NewMessage()
-	msg.Type = METHOD_CALL
+	msg.Type = TypeMethodCall
 	msg.Flags = MessageFlag(0)
 	msg.Path = "/org/freedesktop/DBus"
 	msg.Dest = "org.freedesktop.DBus"


### PR DESCRIPTION
This does various things to improve the Message interface.
- The MessageType and MessageFlag constants are properly typed (no longer int types). This wasn't causing problems. But, it's cleaner and it formats the `godoc` documentation better.
- The MessageType and MessageFlag constant names are more idiomatic Go names. The MessageType names are prefixed with "Type" (to be more explicit and to avoid naming conflicts). The MessageFlag names have not been prefixed. They seem unambiguous enough to me. Any thoughts about that?
- The MessageType now uses method String, instead of _ToString. This is more idiomatic Go. It also allows fmt.Printf to format it better with the flag "%v".
- The Message type's field, Type, is now a MessageType. This speeds up comparison operations. It's also a little clearer than the previous string-based approach (not that it was overly complicated before).

I'm always open to feedback. Let me know what you think

Bryan
